### PR TITLE
unused cache fixed

### DIFF
--- a/copy_this/modules/trustedshopsrich/cache/cache.txt
+++ b/copy_this/modules/trustedshopsrich/cache/cache.txt
@@ -1,0 +1,1 @@
+This folder contains cached TS informations.


### PR DESCRIPTION
- fix wrong cache check (results were retrieved permanently)
- move cache files to module internal cache folder (avoids extensive calls while development, TS has a call restriction)
- cache folder is configurable by config.inc variable
- set cache expiration timespan to 24 hours (TS data does not change more than 24 hours)
- cache expiration timespan is configurable by config.inc variable